### PR TITLE
Use flow check instead of status when param check is pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # flow-phabricator-parser
-A flow output parser to be use with phabricator `arc lint`
 
+A flow output parser to be use with phabricator `arc lint`
 
 This is a simple wrapper - parser for node that will transform the output from [flow]() to something that phabricator can inspect in the linting stage.
 
@@ -9,8 +9,8 @@ This is a simple wrapper - parser for node that will transform the output from [
 Install the package with
 
 ```lang=bash
-npm install flow-phabricator-parser --save-dev 
-#or 
+npm install flow-phabricator-parser --save-dev
+#or
 yarn add flow-phabricator-parser --dev
 ```
 
@@ -34,21 +34,23 @@ create a `.arclint` file and add
 }
 ```
 
-> Replace `PATH_FROM_REPO_ROOT_TO_FLOWCONFIG` in the above with the path to directory containing your project's `project.json` file. 
+> Replace `PATH_FROM_REPO_ROOT_TO_FLOWCONFIG` in the above with the path to directory containing your project's `project.json` file.
 > If it's at the root, remove `/PATH_FROM_REPO_ROOT_TO_FLOWCONFIG` from the path above - including the `/` prefix, so just `.` is left.
 > An optional parameter check can be pass at the end to the script so the line will look like
+>
 > ```$lang=javascript
 > "script-and-regex.script": "sh -c '(node ./PATH_FROM_REPO_ROOT_TO_PROJECT/node_modules/flow-phabricator-parser/flowparser.js ./PATH_FROM_REPO_ROOT_TO_FLOWCONFIG \"$0\" check)'",
-> ```    
+> ```
+>
 > That will force to run flow in mode "check" (independent process) instead of status (server). [Flow #6025](https://github.com/facebook/flow/issues/6025) and [Flow #1428](https://github.com/facebook/flow/issues/1428) are issues that can be work around with this.
 > [Flow modes](https://stackoverflow.com/questions/38902752/whats-the-difference-between-running-flow-and-flow-check/38906176#38906176)
 
-
 Next we need to ensure the appropriate version of flow-bin is installed.
 
-- Open up `.flowconfig` file at the root of your React Native project, and scroll to the bottom.
+* Open up `.flowconfig` file at the root of your React Native project, and scroll to the bottom.
 
 You should see a version, e.g.:
+
 ```
 [version]
 ^0.42.0
@@ -62,21 +64,19 @@ npm install flow-bin@0.42.0 --save-dev
 yarn add flow-bin@0.42.0 --dev
 ```
 
-Notes
-----
+## Notes
 
-We point to `"(\\.js?$)",` to get all the js files changed since last version. Also the parser will discard errors that doesn't belong to changed files. If you think some error reported is cryptic you may want to run flow in your __project folder__. 
+We point to `"(\\.js?$)",` to get all the js files changed since last version. Also the parser will discard errors that doesn't belong to changed files. If you think some error reported is cryptic you may want to run flow in your **project folder**.
 
-On 
+On
 
 ```lang=javascript
 "script-and-regex.script": "sh -c '(node ./ProjectDir/node_modules/flow-phabricator-parser/flowparser.js ./ProjectDir \"$0\")'"
 ```
 
-we need to pass `./ProjectDir ` as the folder where flow will be run (AKA the folder of your `.flowconfig` file) relative to the root of the git repository.
+we need to pass `./ProjectDir` as the folder where flow will be run (AKA the folder of your `.flowconfig` file) relative to the root of the git repository.
 
-Current Limitations
------
+## Current Limitations
 
-- Flow is invoked for each file and the output processed for each different file.
-- Right now, in very big projects with many dependencies in `node_modules`; errors in the parsing are not impossible although really unlikely. To solve this we may need to move from `execFile` to a more robust mechanism.
+* Flow is invoked for each file and the output processed for each different file.
+* Right now, in very big projects with many dependencies in `node_modules`; errors in the parsing are not impossible although really unlikely. To solve this we may need to move from `execFile` to a more robust mechanism.

--- a/README.md
+++ b/README.md
@@ -27,15 +27,22 @@ create a `.arclint` file and add
     "type": "script-and-regex",
     "include": "(\\.js?$)",
     "exclude": [ ],
-    "script-and-regex.script": "sh -c '(node ./PATH_FROM_REPO_ROOT_TO_PROJECT/node_modules/flow-phabricator-parser/flowparser.js ./PATH_FROM_REPO_ROOT_TO_PROJECT \"$0\")'",
+    "script-and-regex.script": "sh -c '(node ./PATH_FROM_REPO_ROOT_TO_PROJECT/node_modules/flow-phabricator-parser/flowparser.js ./PATH_FROM_REPO_ROOT_TO_FLOWCONFIG \"$0\")'",
     "script-and-regex.regex": "/^(?P<file>.*): line (?P<line>[0-9]*), col (?P<char>[0-9]*), (?P<severity>error|warning) - (?P<message>.*) \\((?P<code>[a-z-]+)\\)$/m"
     }
   }
 }
 ```
 
-> Replace `PATH_FROM_REPO_ROOT_TO_PROJECT` in the above with the path to directory containing your project's `project.json` file. 
-> If it's at the root, remove `/PATH_FROM_REPO_ROOT_TO_PROJECT` from the path above - including the `/` prefix.
+> Replace `PATH_FROM_REPO_ROOT_TO_FLOWCONFIG` in the above with the path to directory containing your project's `project.json` file. 
+> If it's at the root, remove `/PATH_FROM_REPO_ROOT_TO_FLOWCONFIG` from the path above - including the `/` prefix, so just `.` is left.
+> An optional parameter check can be pass at the end to the script so the line will look like
+> ```$lang=javascript
+> "script-and-regex.script": "sh -c '(node ./PATH_FROM_REPO_ROOT_TO_PROJECT/node_modules/flow-phabricator-parser/flowparser.js ./PATH_FROM_REPO_ROOT_TO_FLOWCONFIG \"$0\" check)'",
+> ```    
+> That will force to run flow in mode "check" (independent process) instead of status (server). [Flow #6025](https://github.com/facebook/flow/issues/6025) and [Flow #1428](https://github.com/facebook/flow/issues/1428) are issues that can be work around with this.
+> [Flow modes](https://stackoverflow.com/questions/38902752/whats-the-difference-between-running-flow-and-flow-check/38906176#38906176)
+
 
 Next we need to ensure the appropriate version of flow-bin is installed.
 

--- a/flowparser.js
+++ b/flowparser.js
@@ -47,7 +47,7 @@ try
     path = process.cwd() + "/" + file;
     const child = execFile(
         flow,
-        ['--json'],
+        ['check', '--json'],
         {
             cwd: dir,
             // This should bullet proof an issue where the flow output is too big

--- a/flowparser.js
+++ b/flowparser.js
@@ -8,65 +8,61 @@
  *  parse it. The output can then be feed to `arc lint` and included in the
  *  arc diff workflow
  */
- 
-"use strict";
+
+'use strict';
 const execFile = require('child_process').execFile;
 const flow = require('flow-bin');
 const dir = process.argv[2];
 const file = process.argv[3];
+const mode = process.argv[4];
+let options = ['check', '--json'];
+if (mode !== 'check') {
+  options = ['--json'];
+}
 const flowError = 'flow-type-error';
 let path;
-function parseOutput(json, path)
-{
-    // Pretended output, one per line
-    // ${file}: line ${line}, col ${col}, ${error-type} - {issue-type}. (code)
-    let output = "";
-    if(json.passed === false)
-    {
-        const arrayOfStrings = json.errors.map(
-            errorObject =>
-            {
-                let info = errorObject.message[0];
-                if(path !== info.path)
-                {
-                    return "";
-                }
-                return `${info.path}: line ${info.line}, col ${info.start}, ${errorObject.level} - ${errorObject.message.reduce(
-                    (a, b) => `${a} ${b.descr}`, ""
-                )}. (${flowError})`;
-            }
-        );
-        output = arrayOfStrings.reduce((a, b) => `${a}\n${b}`);
-    }
-    return output;
+function parseOutput(json, path) {
+  // Pretended output, one per line
+  // ${file}: line ${line}, col ${col}, ${error-type} - {issue-type}. (code)
+  let output = '';
+  if (json.passed === false) {
+    const arrayOfStrings = json.errors.map(errorObject => {
+      let info = errorObject.message[0];
+      if (path !== info.path) {
+        return '';
+      }
+      return `${info.path}: line ${info.line}, col ${info.start}, ${errorObject.level} - ${errorObject.message.reduce(
+        (a, b) => `${a} ${b.descr}`,
+        ''
+      )}. (${flowError})`;
+    });
+    output = arrayOfStrings.reduce((a, b) => `${a}\n${b}`);
+  }
+  return output;
 }
 
 // Catch flow as if some error is found it would exit with a code != 0
-try
-{
-    path = process.cwd() + "/" + file;
-    const child = execFile(
-        flow,
-        ['check', '--json'],
-        {
-            cwd: dir,
-            // This should bullet proof an issue where the flow output is too big
-            // for the default value (50MB buffer size)
-            // This should not be necessary when 
-            // https://github.com/facebook/flow/issues/2364 is solved
-            maxBuffer: 50*1024*1024, 
-        },
-        (error, stdout) =>
-        {
-            let json = JSON.parse(stdout);
-            console.log(parseOutput(json, path));
-        }
-    );
+try {
+  console.warn('options are', options);
+  path = process.cwd() + '/' + file;
+  const child = execFile(
+    flow,
+    options,
+    {
+      cwd: dir,
+      // This should bullet proof an issue where the flow output is too big
+      // for the default value (50MB buffer size)
+      // This should not be necessary when
+      // https://github.com/facebook/flow/issues/2364 is solved
+      maxBuffer: 50 * 1024 * 1024,
+    },
+    (error, stdout) => {
+      let json = JSON.parse(stdout);
+      console.log(parseOutput(json, path));
+      return 0;
+    }
+  );
+} catch (err) {
+  let json = JSON.parse(err.stdout);
+  console.log(parseOutput(json, path));
 }
-catch(err)
-{
-    let json = JSON.parse(err.stdout);
-    console.log(parseOutput(json, path));
-}
-
-return 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-phabricator-parser",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A flow output parser to be use with phabricator `arc lint`",
   "main": "flowparser.js",
   "scripts": {


### PR DESCRIPTION
Because the issues linked in the readme some times it might be useful to run flow check and trade some speed for stability.

This change is opt in and it does not changes the previous behaviour.